### PR TITLE
Allow duplicate servers in ServerList

### DIFF
--- a/lib/net/ssh/multi/server_list.rb
+++ b/lib/net/ssh/multi/server_list.rb
@@ -13,7 +13,9 @@ module Net; module SSH; module Multi
     # Create a new ServerList that wraps the given server list. Duplicate entries
     # will be discarded.
     def initialize(list=[])
-      @list = list.uniq
+      options = list.last.is_a?(Hash) ? list.pop : {}
+      @allow_duplicate_servers = options.delete :allow_duplicate_servers
+      @list = @allow_duplicate_servers ? list : list.uniq
     end
 
     # Adds the given server to the list, and returns the argument. If an
@@ -21,11 +23,15 @@ module Net; module SSH; module Multi
     # argument is _not_ added, and the existing server record is returned
     # instead.
     def add(server)
-      index = @list.index(server)
-      if index
-        server = @list[index]
-      else
+      if @allow_duplicate_servers
         @list.push(server)
+      else
+        index = @list.index(server)
+        if index
+          server = @list[index]
+        else
+          @list.push(server)
+        end
       end
       server
     end
@@ -71,7 +77,7 @@ module Net; module SSH; module Multi
         end
       end
 
-      result.uniq
+      @allow_duplicate_servers ? result : result.uniq
     end
 
     alias to_ary flatten

--- a/lib/net/ssh/multi/session.rb
+++ b/lib/net/ssh/multi/session.rb
@@ -142,6 +142,11 @@ module Net; module SSH; module Multi
     # :warn if connection errors should cause a warning.
     attr_accessor :on_error
 
+    # Whether to allow duplicate server definitions. This defaults to false,
+    # but you may set it to true if you really want to run parallel commands on
+    # the same server.
+    attr_accessor :allow_duplicate_servers
+
     # The default user name to use when connecting to a server. If a user name
     # is not given for a particular server, this value will be used. It defaults
     # to ENV['USER'] || ENV['USERNAME'], or "unknown" if neither of those are
@@ -169,7 +174,7 @@ module Net; module SSH; module Multi
     #     session.use ...
     #   end
     def initialize(options={})
-      @server_list = ServerList.new
+      @server_list = ServerList.new([ { :allow_duplicate_servers => options[:allow_duplicate_servers] } ])
       @groups = Hash.new { |h,k| h[k] = ServerList.new }
       @gateway = nil
       @open_groups = []
@@ -357,7 +362,7 @@ module Net; module SSH; module Multi
           aggregator.concat(servers)
         end
 
-        list.uniq
+        allow_duplicate_servers ? list : list.uniq
       end
     end
 


### PR DESCRIPTION
Hi Jamis,

I've got a use case in which I want to be able to run N commands in parallel on the same server, but that seems to be currently disallowed because of the uniquify logic in ServerList - I can't add the same server N times, which is what I want (I think).

I've added an :allow_duplicate_servers option to Session and ServerList to allow this behaviour to be turned off. Can you review/comment? Happy to rework further if this is a direction you're comfortable with.

Cheers,
Gavin
